### PR TITLE
Fixes for hypercat helper functions for apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ DataSourceMetadata objects are used to describe your data source when creating a
 
 **Returns** an object of the form { "DataSourceMetadata": <DataSourceMetadata>, "DataSourceURL":store_url}
 
-### HypercatToDataStoreUrl (hyperCatString)
+### GetStoreURLFromHypercat (hyperCatString)
 
  Name | Type | Description |
 | ---- | ---- | ----------- |
 | _hyperCatString_ | `String` | A string representation of the hypercat Item representing a data source |
 
-**Returns** a string holding the store endpoint URL
+**Returns** a string holding the store endpoint URL (for use in NewStoreClient)
 
 ## Using the databox core-store
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,21 @@ DataSourceMetadata objects are used to describe your data source when creating a
 
 **Returns** An object representing the hypercat item represented by DataSourceMetadata.
 
-### HypercatToSourceDataMetadata (hyperCatString)
+### HypercatToDataSourceMetadata (hyperCatString)
 
  Name | Type | Description |
 | ---- | ---- | ----------- |
 | _hyperCatString_ | `String` | A string representation of the hypercat Item representing a data source |
 
-**Returns** A promise that resolves to an object of the form { "DataSourceMetadata": <DataSourceMetadata>, "DataSourceURL":store_url}
+**Returns** an object of the form { "DataSourceMetadata": <DataSourceMetadata>, "DataSourceURL":store_url}
 
+### HypercatToDataStoreUrl (hyperCatString)
+
+ Name | Type | Description |
+| ---- | ---- | ----------- |
+| _hyperCatString_ | `String` | A string representation of the hypercat Item representing a data source |
+
+**Returns** a string holding the store endpoint URL
 
 ## Using the databox core-store
 
@@ -83,7 +90,7 @@ The time series API has support for writing generic JSON blobs (see TSBlob) or d
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _STORE_URI_ | `String` | dataStore to access found in DATABOX_STORE_URL for drivers and in the DATASOURCE_[clientId] for each datasource required by an app |
+| _STORE_URI_ | `String` | dataStore to access found in DATABOX_STORE_URL for drivers and in HypercatToDataStoreUrl( DATASOURCE_[clientId] ) for each datasource required by an app |
 | _ARBITER_URI_ | `String` | the URI to the arbiter available in DATABOX_ARBITER_ENDPOINT env var within databox |
 | _enableLogging_ | `Bool` | Turns on verbose debug output |
 
@@ -259,11 +266,7 @@ These functions allow you to manage unstructured json data in the time series st
 
 > :warning: If data is written into a TimeSeriesBlobStore filtering and aggregation functions are not supported.
 
-The NewStoreClient.TSBlob supports the following functions:
-
-### databox.NewStoreClient.TSBlob (reqEndpoint, enableLogging)
-
-**Returns** a new NewStoreClient.TSBlob that is connected to the provided store.
+The StoreClient.TSBlob supports the following functions:
 
 ### StoreClient.TSBlob.Write (dataSourceID, payload)
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The time series API has support for writing generic JSON blobs (see TSBlob) or d
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _STORE_URI_ | `String` | dataStore to access found in DATABOX_STORE_URL for drivers and in HypercatToDataStoreUrl( DATASOURCE_[clientId] ) for each datasource required by an app |
+| _STORE_URI_ | `String` | dataStore to access found in DATABOX_STORE_URL for drivers and in GetStoreURLFromHypercat( DATASOURCE_[clientId] ) for each datasource required by an app |
 | _ARBITER_URI_ | `String` | the URI to the arbiter available in DATABOX_ARBITER_ENDPOINT env var within databox |
 | _enableLogging_ | `Bool` | Turns on verbose debug output |
 

--- a/lib/zest.js
+++ b/lib/zest.js
@@ -137,12 +137,16 @@ module.exports = function (endpoint, dealerEndpoint, serverKey, logging) {
                 this.Observers[path] = { dealer, EE }
 
                 dealer.on('message', function (msg) {
+                    let zh
                     try {
-                        let zh = handleResponse(msg)
-                        EE.emit('data', zh.payload)
+                        log('dealer.on message')
+                        zh = handleResponse(msg)
                     } catch (err) {
+                        log('dealer msg handling error: '+err)
                         EE.emit('error', msg)
                     }
+                    if (zh)
+                        EE.emit('data', zh.payload)
                 })
 
                 dealer.on('error', function (msg) {

--- a/main.js
+++ b/main.js
@@ -33,12 +33,6 @@ exports.NewStoreClient = function (storeEndpoint, arbiterEndpoint, enableLogging
             return _read(arbiterCli, zestCli, '/cat', '/cat', 'JSON')
         },
 
-        getStoreUrlFromHypercat: function (hypercat) {
-            let dsm = HypercatToSourceDataMetadata(hypercat)
-            let u = url.parse(hypercatObj.href)
-            return u.protocol + '//' + u.host
-        },
-
         //KeyValueClient used to read and write of data key value to the store
         KV: {
             Read: async function (dataSourceID, key, contentFormat = 'JSON') {
@@ -233,12 +227,12 @@ let DataSourceMetadataToHypercat = function (endpoint, metadata) {
 }
 exports.DataSourceMetadataToHypercat = DataSourceMetadataToHypercat
 
-let HypercatToSourceDataMetadata = function (hyperCat) {
+let HypercatToDataSourceMetadata = function (hyperCat) {
 
     let dm = NewDataSourceMetadata()
 
     if (typeof (hyperCat) === 'string') {
-        hyperCat = JSON.parse(hyperCatString)
+        hyperCat = JSON.parse(hyperCat)
     }
 
     hyperCat['item-metadata'].forEach(element => {
@@ -273,7 +267,15 @@ let HypercatToSourceDataMetadata = function (hyperCat) {
 
     return dm
 }
-exports.HypercatToSourceDataMetadata = HypercatToSourceDataMetadata
+exports.HypercatToDataSourceMetadata = HypercatToDataSourceMetadata
+
+exports.HypercatToDataStoreUrl = function (hyperCat) {
+	if (typeof(hyperCat) === 'string') {
+		hyperCat = JSON.parse(hyperCat);
+	}
+	let u = url.parse(hyperCat.href)
+	return u.protocol + '//' + u.host
+}
 
 exports.GetHttpsCredentials = function () {
 

--- a/main.js
+++ b/main.js
@@ -269,7 +269,7 @@ let HypercatToDataSourceMetadata = function (hyperCat) {
 }
 exports.HypercatToDataSourceMetadata = HypercatToDataSourceMetadata
 
-exports.HypercatToDataStoreUrl = function (hyperCat) {
+exports.GetStoreURLFromHypercat = function (hyperCat) {
 	if (typeof(hyperCat) === 'string') {
 		hyperCat = JSON.parse(hyperCat);
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-databox",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "A NodeJs Lib for Zest REST over ZeroMQ",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Strictly a breaking change, due to renaming HypercatToSourceDataMetadata to HypercatToDataSourceMetadata for consistency with go libs, and moving/renaming StoreClient.getStoreUrlFromHypercat to (top level) GetStoreURLFromHypercat (but that function was broken anyway)